### PR TITLE
Update README.md license badge to explicitly show Unlicense

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/core-rs/issues/3
-Your prepared branch: issue-3-a59a76e5e0ca
-Your prepared working directory: /tmp/gh-issue-solver-1766852587898
-
-Proceed.


### PR DESCRIPTION
## Summary

This PR updates the license information in all places to reflect the actual Unlicense license, addressing issue #3.

## Changes Made

### ✅ Cargo.toml
Already updated in PR #4 - `license = "Unlicense"`

### ✅ LICENSE file
Contains the full Unlicense text - no changes needed

### ✅ README.md
- Updated the license badge from `https://img.shields.io/crates/l/platform-data` to an explicit Unlicense badge
- New badge: `https://img.shields.io/badge/license-Unlicense-blue.svg`
- This makes it immediately clear that the project uses the Unlicense

### Source Files
Rust projects typically don't include license headers in source files when the license is specified in Cargo.toml, which is the standard practice. The Cargo.toml `license` field is the canonical source of license information for Rust crates.

## Verification

All license references now consistently point to the Unlicense:
- `Cargo.toml`: `license = "Unlicense"`
- `LICENSE`: Full Unlicense text
- `README.md`: Explicit "Unlicense" badge

## Closes

Fixes #3

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)